### PR TITLE
Feat: #9 #10 User id 타입 및 응답 코드 포맷 변경

### DIFF
--- a/backend/dguonoff/src/main/java/backend/spectrum/dguonoff/domain/user/api/MasterAdminController.java
+++ b/backend/dguonoff/src/main/java/backend/spectrum/dguonoff/domain/user/api/MasterAdminController.java
@@ -26,8 +26,8 @@ public class MasterAdminController {
     //관리자 권한 부여 기능
     @PostMapping("/empowerment")
     public ResponseEntity<String> grantAdminAuthority(@RequestBody EmpowermentParams empParams){
-        Long adminId = empParams.getAdminId();
-        Long userId = empParams.getUserId();
+        String adminId = empParams.getAdminId();
+        String userId = empParams.getUserId();
 
         userService.checkMasterAdmin(adminId);
         User targetUser = userService.findUser(userId);

--- a/backend/dguonoff/src/main/java/backend/spectrum/dguonoff/domain/user/dto/EmpowermentParams.java
+++ b/backend/dguonoff/src/main/java/backend/spectrum/dguonoff/domain/user/dto/EmpowermentParams.java
@@ -4,6 +4,6 @@ import lombok.Data;
 
 @Data
 public class EmpowermentParams {
-    Long userId;
-    Long adminId;
+    String userId;
+    String adminId;
 }

--- a/backend/dguonoff/src/main/java/backend/spectrum/dguonoff/domain/user/entity/User.java
+++ b/backend/dguonoff/src/main/java/backend/spectrum/dguonoff/domain/user/entity/User.java
@@ -15,7 +15,7 @@ public class User {
 
     @Id
     @Column(name = "id", nullable = false)
-    private Long id;
+    private String id;
 
     @Column(name = "password", length = 512, nullable = false)
     private String password;

--- a/backend/dguonoff/src/main/java/backend/spectrum/dguonoff/domain/user/repository/UserRepository.java
+++ b/backend/dguonoff/src/main/java/backend/spectrum/dguonoff/domain/user/repository/UserRepository.java
@@ -9,10 +9,10 @@ import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
 @Repository
-public interface UserRepository extends JpaRepository<User, Long> {
+public interface UserRepository extends JpaRepository<User, String> {
     @Transactional
     @Modifying
     @Query("update User u set u.role = 'ADMIN' where u.id = ?1")
-    int changeRoleToAdmin(@NonNull Long id);
+    int changeRoleToAdmin(@NonNull String id);
 
 }

--- a/backend/dguonoff/src/main/java/backend/spectrum/dguonoff/domain/user/service/UserService.java
+++ b/backend/dguonoff/src/main/java/backend/spectrum/dguonoff/domain/user/service/UserService.java
@@ -17,7 +17,7 @@ public class UserService {
     }
 
     //유저 조회 함수
-    public User findUser(Long userId) {
+    public User findUser(String userId) {
         User user = userRepository
                 .findById(userId)
                 .orElseThrow(() -> new UserNotFoundException(ErrorCode.NOT_EXIST_USER));
@@ -26,7 +26,7 @@ public class UserService {
     }
 
     //마스터 관리자 조회 및 권한 확인 함수
-    public void checkMasterAdmin(Long userId) {
+    public void checkMasterAdmin(String userId) {
         User user = userRepository
                 .findById(userId)
                 .orElseThrow(() -> new UserNotFoundException(ErrorCode.NOT_EXIST_MASTER_ADMIN));

--- a/backend/dguonoff/src/main/java/backend/spectrum/dguonoff/global/error/ErrorResponse.java
+++ b/backend/dguonoff/src/main/java/backend/spectrum/dguonoff/global/error/ErrorResponse.java
@@ -10,7 +10,7 @@ public class ErrorResponse {
 
     public ErrorResponse(ErrorCode code) {
         this.message = code.getMessage();
-        this.code = code.getCode();
+        this.code = code.name();
     }
 
 }

--- a/backend/dguonoff/src/main/java/backend/spectrum/dguonoff/global/statusCode/CommonCode.java
+++ b/backend/dguonoff/src/main/java/backend/spectrum/dguonoff/global/statusCode/CommonCode.java
@@ -9,7 +9,7 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public enum CommonCode {
     //User
-    SUCCESS_EMPOWERMENT(HttpStatus.OK, "%d 계정에 관리자 권한이 부여됐습니다."),
+    SUCCESS_EMPOWERMENT(HttpStatus.OK, "%s 계정에 관리자 권한이 부여됐습니다."),
 
     ;
     private final HttpStatus status;

--- a/backend/dguonoff/src/main/java/backend/spectrum/dguonoff/global/statusCode/CommonCode.java
+++ b/backend/dguonoff/src/main/java/backend/spectrum/dguonoff/global/statusCode/CommonCode.java
@@ -9,11 +9,10 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public enum CommonCode {
     //User
-    SUCCESS_EMPOWERMENT(HttpStatus.OK, "S-U001", "%d 계정에 관리자 권한이 부여됐습니다."),
+    SUCCESS_EMPOWERMENT(HttpStatus.OK, "%d 계정에 관리자 권한이 부여됐습니다."),
 
     ;
     private final HttpStatus status;
-    private final String code;
     private final String message;
 
 }

--- a/backend/dguonoff/src/main/java/backend/spectrum/dguonoff/global/statusCode/ErrorCode.java
+++ b/backend/dguonoff/src/main/java/backend/spectrum/dguonoff/global/statusCode/ErrorCode.java
@@ -10,18 +10,17 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
 
     //User
-    NOT_EXIST_USER(HttpStatus.NOT_FOUND, "E-U001", "존재하지 않는 유저입니다."),
-    NOT_EXIST_MASTER_ADMIN(HttpStatus.NOT_FOUND, "E-U002", "존재하지 않는 마스터 관리자입니다."),
-    NO_AUTH(HttpStatus.FORBIDDEN, "E-U003", "권한이 없는 유저입니다."),
+    NOT_EXIST_USER(HttpStatus.NOT_FOUND, "존재하지 않는 유저입니다."),
+    NOT_EXIST_MASTER_ADMIN(HttpStatus.NOT_FOUND, "존재하지 않는 마스터 관리자입니다."),
+    NO_AUTH(HttpStatus.FORBIDDEN, "권한이 없는 유저입니다."),
 
 
     //Common
-    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "E-COM001", "허용되지 않은 메소드입니다."),
-    SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "E-COM002", "서버 내부 에러가 발생하였습니다."),
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "허용되지 않은 메소드입니다."),
+    SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 에러가 발생하였습니다."),
     ;
 
     private final HttpStatus status;
-    private final String code;
     private final String message;
 
 }

--- a/backend/dguonoff/src/test/java/backend/spectrum/dguonoff/Service/UserServiceTest.java
+++ b/backend/dguonoff/src/test/java/backend/spectrum/dguonoff/Service/UserServiceTest.java
@@ -28,8 +28,8 @@ public class UserServiceTest {
 
     @BeforeEach
     void setUp() { // 테스트에 필요한 초기 데이터를 설정
-        userA = new User(100L, "1234", Role.NORMAL, "userA", "CSE", "user@test.com");
-        masterA = new User(200L, "1234", Role.MASTER, "MasterA", "CSE", "master@test.com");
+        userA = new User("100N", "1234", Role.NORMAL, "userA", "CSE", "user@test.com");
+        masterA = new User("200M", "1234", Role.MASTER, "MasterA", "CSE", "master@test.com");
 
         userRepository.save(userA);
         userRepository.save(masterA);
@@ -43,7 +43,7 @@ public class UserServiceTest {
     @DisplayName("존재하는 아이디로 조회하면 그 유저를 조회할 수 있다.")
     @Test
     public void 존재하는_유저조회() {
-        Long checkId = 100L;
+        String checkId = "100N";
         User findUser = userService.findUser(checkId);
 
         assertThat(findUser.getName()).isEqualTo(userA.getName());
@@ -52,7 +52,7 @@ public class UserServiceTest {
     @DisplayName("존재하지 않는 아이디로 조회하면 예외가 발생한다.")
     @Test
     public void 존재하지_않는_유저조회() {
-        Long notExistUserId = 101L;
+        String notExistUserId = "101N";
 
         assertThatExceptionOfType(UserNotFoundException.class).isThrownBy(() -> {
             userService.findUser(notExistUserId);
@@ -63,7 +63,7 @@ public class UserServiceTest {
     @DisplayName("마스터 관리자 아이디로 권한 확인하면 관리자 권한이 있는지 확인할 수 있다.")
     @Test
     public void 마스터_관리자_권한_확인() {
-        Long checkId = 200L;
+        String checkId = "200M";
 
         assertThatCode(() -> {
             userService.checkMasterAdmin(checkId);
@@ -73,7 +73,7 @@ public class UserServiceTest {
     @DisplayName("존재하지 않는 아이디로 권한 확인하면 예외가 발생한다.")
     @Test
     public void 존재하지_않는_아이디_권한_확인() {
-        Long checkId = 300L;
+        String checkId = "300M";
 
         assertThatExceptionOfType(UserNotFoundException.class).isThrownBy(() -> {
             userService.checkMasterAdmin(checkId);
@@ -83,7 +83,7 @@ public class UserServiceTest {
     @DisplayName("관리자가 아닌 아이디로 권한 확인하면 예외가 발생한다.")
     @Test
     public void 마스터_관리자_아닌_아이디로_권한_확인() {
-        Long checkId = 100L;
+        String checkId = "100N";
 
         assertThatExceptionOfType(InvalidAccessException.class).isThrownBy(() -> {
             userService.checkMasterAdmin(checkId);


### PR DESCRIPTION
## 관련 이슈 및 링크
- #9 
- #10 

## 구현 및 변경 사항
### User id 타입 변경
- User id의 타입을 기존 Long에서 String으로 변경
- User id와 관련된 함수와 테스트 코드에 반영

### 응답 코드 포맷 변경
-  CommonCode와 ErroCode의 String code 필드를 제거
-  ErrorResponse의 생성자에서 기존 ErrorCode의 "자체 code"가 아닌 ErrorCode의 "ENUM명"을 code를 사용하도록 변경 
 -> 코드 포맷 이슈 & 코드 자체에 의미를 부여함

## 테스트 완료 사항
-  기존 정상/예외 처리 시나리오 테스트 완료

## 스크린샷
<img width="895" alt="스크린샷 2023-11-22 오후 2 47 32" src="https://github.com/shortboy7/2023-2-SWE-DGU-ON-AND-OFF/assets/45763117/5c7ef7c4-4b75-4b30-877f-ae6ec5e5cb7e">

## 리뷰 요청 사항
- 변경 사항 확인 및 반영되지 않은 코드 있는지 검토 부탁드립니다.