### PR TITLE
Feat: #48 시설물 다음 일정 조회 기능 구현

### DIFF
--- a/backend/dguonoff/src/main/java/backend/spectrum/dguonoff/domain/facility/api/FacilityController.java
+++ b/backend/dguonoff/src/main/java/backend/spectrum/dguonoff/domain/facility/api/FacilityController.java
@@ -2,6 +2,7 @@ package backend.spectrum.dguonoff.domain.facility.api;
 
 import backend.spectrum.dguonoff.DAO.model.FacilityStatus;
 import backend.spectrum.dguonoff.domain.facility.dto.FloorFacilityListResponse;
+import backend.spectrum.dguonoff.domain.facility.dto.NextReservationResponse;
 import backend.spectrum.dguonoff.domain.facility.service.FacilityService;
 import java.security.Principal;
 import lombok.RequiredArgsConstructor;
@@ -9,8 +10,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import static backend.spectrum.dguonoff.global.statusCode.CommonCode.SUCCESS_FACILITY_FINISH;
-import static backend.spectrum.dguonoff.global.statusCode.CommonCode.SUCCESS_FACILITY_LOOKUP;
+import static backend.spectrum.dguonoff.global.statusCode.CommonCode.*;
 
 @RestController
 @RequestMapping("/api/facility")
@@ -35,10 +35,20 @@ public class FacilityController {
         return ResponseEntity.ok(facilityList);
     }
 
+    //특정 시설물 다음 예약 조회 기능
+    @GetMapping("/next/{facilityCode}")
+    public ResponseEntity<NextReservationResponse> getNextReservation(@PathVariable String facilityCode){
+        NextReservationResponse nextReservation = facilityService.getNextReservation(facilityCode);
+
+        HttpStatus successStatus = SUCCESS_FACILITY_NEXT_RESERVATION_LOOKUP.getStatus();
+
+        return new ResponseEntity(nextReservation, successStatus);
+    }
+
     //특정 시설물 이용상태 확인 기능
-    @GetMapping("/status/{facilityId}")
-    public ResponseEntity<String> getFacilityStatus(@PathVariable String facilityId){
-        FacilityStatus facilityStatus = facilityService.getFacilityStatus(facilityId);
+    @GetMapping("/status/{facilityCode}")
+    public ResponseEntity<String> getFacilityStatus(@PathVariable String facilityCode){
+        FacilityStatus facilityStatus = facilityService.getFacilityStatus(facilityCode);
 
         HttpStatus successStatus = SUCCESS_FACILITY_LOOKUP.getStatus();
 
@@ -46,9 +56,9 @@ public class FacilityController {
     }
 
     //시설물 이용 종료 기능
-    @GetMapping("/finish/{facilityId}")
-    public ResponseEntity<String> endFacility(@PathVariable String facilityId){
-        facilityService.endFacility(facilityId);
+    @GetMapping("/finish/{facilityCode}")
+    public ResponseEntity<String> endFacility(@PathVariable String facilityCode){
+        facilityService.endFacility(facilityCode);
 
         String successMessage = SUCCESS_FACILITY_FINISH.getMessage();
         HttpStatus successStatus = SUCCESS_FACILITY_FINISH.getStatus();

--- a/backend/dguonoff/src/main/java/backend/spectrum/dguonoff/domain/facility/dto/NextReservationResponse.java
+++ b/backend/dguonoff/src/main/java/backend/spectrum/dguonoff/domain/facility/dto/NextReservationResponse.java
@@ -1,0 +1,19 @@
+package backend.spectrum.dguonoff.domain.facility.dto;
+
+import backend.spectrum.dguonoff.DAO.model.FacilityStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class NextReservationResponse {
+    private FacilityStatus status;
+    private LocalDate date;
+    private LocalTime startTime;
+    private LocalTime endTime;
+}

--- a/backend/dguonoff/src/main/java/backend/spectrum/dguonoff/domain/facility/repository/FacilityRepository.java
+++ b/backend/dguonoff/src/main/java/backend/spectrum/dguonoff/domain/facility/repository/FacilityRepository.java
@@ -1,9 +1,12 @@
 package backend.spectrum.dguonoff.domain.facility.repository;
 
 import backend.spectrum.dguonoff.DAO.Facility;
+
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
+import backend.spectrum.dguonoff.DAO.Reservation;
 import backend.spectrum.dguonoff.DAO.model.FacilityStatus;
 import backend.spectrum.dguonoff.domain.reservation.dto.constraint.DateConstraint;
 import backend.spectrum.dguonoff.domain.reservation.dto.constraint.MaxReservationConstraint;

--- a/backend/dguonoff/src/main/java/backend/spectrum/dguonoff/domain/facility/service/FacilityService.java
+++ b/backend/dguonoff/src/main/java/backend/spectrum/dguonoff/domain/facility/service/FacilityService.java
@@ -1,34 +1,41 @@
 package backend.spectrum.dguonoff.domain.facility.service;
 
-import backend.spectrum.dguonoff.DAO.Bookmark;
-import backend.spectrum.dguonoff.DAO.Building;
-import backend.spectrum.dguonoff.DAO.Facility;
-import backend.spectrum.dguonoff.DAO.User;
+import backend.spectrum.dguonoff.DAO.*;
 import backend.spectrum.dguonoff.DAO.model.FacilityStatus;
 import backend.spectrum.dguonoff.domain.facility.converter.FacilityConverter;
 import backend.spectrum.dguonoff.domain.facility.dto.BuildingDTO;
 import backend.spectrum.dguonoff.domain.facility.dto.FacilityOutlineDTO;
 import backend.spectrum.dguonoff.domain.facility.dto.FloorFacilityListResponse;
+import backend.spectrum.dguonoff.domain.facility.dto.NextReservationResponse;
 import backend.spectrum.dguonoff.domain.facility.exception.FacilityNotFoundException;
 import backend.spectrum.dguonoff.domain.facility.repository.BuildingRepository;
 import backend.spectrum.dguonoff.domain.facility.repository.FacilityRepository;
 import backend.spectrum.dguonoff.domain.reservation.dto.constraint.UsageConstraint;
+import backend.spectrum.dguonoff.domain.reservation.repository.ReservationRepository;
 import backend.spectrum.dguonoff.domain.user.exception.UserNotFoundException;
 import backend.spectrum.dguonoff.domain.user.repository.UserRepository;
 import backend.spectrum.dguonoff.global.statusCode.ErrorCode;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import static backend.spectrum.dguonoff.DAO.model.FacilityStatus.USING;
+import static backend.spectrum.dguonoff.DAO.model.ReservationStatus.APPROVED;
+
 @Service
 @Slf4j
 @RequiredArgsConstructor
 public class FacilityService {
+    private final ReservationRepository reservationRepository;
     private final BuildingRepository buildingRepository;
     private final FacilityRepository facilityRepository;
     private final UserRepository userRepository;
@@ -48,7 +55,7 @@ public class FacilityService {
         List<Bookmark> userBookmarks = user.getBookmarks();
         // 시설물 정보를 가져온다.
         List<Facility> facilities = facilityRepository.findAllByBuilding_NameAndFloorAndIsBookable(
-               buildingName, floor, true);
+                buildingName, floor, true);
         // 북마크 정보를 반영한다.
         List<FacilityOutlineDTO> outlines = getFacilityOutlines(buildingName, userBookmarks, facilities);
 
@@ -77,17 +84,17 @@ public class FacilityService {
     }
 
     private static List<FacilityOutlineDTO> getFacilityOutlines(String buildingName,
-                                                                   List<Bookmark> userBookmarks,
-                                                                   List<Facility> facilities) {
+                                                                List<Bookmark> userBookmarks,
+                                                                List<Facility> facilities) {
         // entity를 dto로 바꾼다.
         List<FacilityOutlineDTO> outlines = facilities.stream()
                 .map(FacilityConverter::toFacilityOutlineDTO)
                 .collect(Collectors.toList());
         // 등록된 bookmark 정보를 반영한다.S
-        outlines.forEach(outline-> {
+        outlines.forEach(outline -> {
             Optional<Bookmark> matched = userBookmarks.stream().filter(bookmark ->
-                bookmark.getFacility().getCode().equals(outline.getCode()) &&
-                        bookmark.getFacility().getBuilding().getName().equals(buildingName)
+                    bookmark.getFacility().getCode().equals(outline.getCode()) &&
+                            bookmark.getFacility().getBuilding().getName().equals(buildingName)
             ).findAny();
             if (matched.isPresent())
                 outline.setBookmarked(true);
@@ -112,5 +119,47 @@ public class FacilityService {
     //시설물 이용 상태 종료 함수
     public void endFacility(String facilityCode) {
         facilityRepository.updateFacilityStatus(FacilityStatus.EMPTY, facilityCode);
+    }
+
+    //시설물의 다음 예약 정보를 반환하는 함수
+    public NextReservationResponse getNextReservation(String facilityCode) {
+        LocalDate yesterday = LocalDate.now().minusDays(1);
+        LocalTime currentTime = LocalTime.now();
+        FacilityStatus status = USING;
+
+        List<Reservation> reservations = reservationRepository.findReservationsAfterYesterday(facilityCode, yesterday, APPROVED)
+                .orElseThrow(() -> new FacilityNotFoundException(ErrorCode.NEXT_RESERVATION_NOT_EXIST_FACILITY));
+
+        // 이미 실행 중인 예약 찾기
+        Optional<Reservation> nearestReservation = findOngoingReservation(currentTime, reservations);
+
+        // 실행 중인 예약이 없다면 현재 시각 이후의 예약 중에서 가장 가까운 예약 찾기
+        if (!nearestReservation.isPresent()) {
+            nearestReservation = findNearestReservation(currentTime, reservations);
+            if(!nearestReservation.isPresent()) {
+                throw new FacilityNotFoundException(ErrorCode.NEXT_RESERVATION_NOT_EXIST_FACILITY);
+            }
+            status = FacilityStatus.EMPTY;
+        }
+
+        return NextReservationResponse.builder()
+                .status(status)
+                .date(nearestReservation.get().getDate())
+                .startTime(nearestReservation.get().getStartTime())
+                .endTime(nearestReservation.get().getEndTime())
+                .build();
+    }
+
+    private Optional<Reservation> findNearestReservation(LocalTime currentTime, List<Reservation> reservations) {
+        return reservations.stream()
+                .filter(reservation -> reservation.getStartTime().isAfter(currentTime))
+                .findFirst();
+    }
+
+    private Optional<Reservation> findOngoingReservation(LocalTime currentTime, List<Reservation> reservations) {
+        return reservations.stream()
+                .filter(reservation -> reservation.getStartTime().isBefore(currentTime) &&
+                        reservation.getEndTime().isAfter(currentTime))
+                .findFirst();
     }
 }

--- a/backend/dguonoff/src/main/java/backend/spectrum/dguonoff/domain/reservation/api/ReservationController.java
+++ b/backend/dguonoff/src/main/java/backend/spectrum/dguonoff/domain/reservation/api/ReservationController.java
@@ -165,5 +165,4 @@ public class ReservationController {
         return new ResponseEntity(successMessage, successStatus);
     }
 
-
 }

--- a/backend/dguonoff/src/main/java/backend/spectrum/dguonoff/domain/reservation/repository/ReservationRepository.java
+++ b/backend/dguonoff/src/main/java/backend/spectrum/dguonoff/domain/reservation/repository/ReservationRepository.java
@@ -16,6 +16,8 @@ import java.util.Optional;
 
 @Repository
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
+    @Query("select r from Reservation r where r.facility.code = ?1 and r.date > ?2 and r.status = ?3 order by r.date asc, r.startTime asc")
+    Optional<List<Reservation>> findReservationsAfterYesterday(String code, LocalDate date, ReservationStatus status);
     @Query("select r.event from Reservation r where r.reservationId = ?1")
     Optional<Event> findEventById(Long reservationId);
     @Query("select r from Reservation r where r.facility.code = ?1 and r.date = ?2")

--- a/backend/dguonoff/src/main/java/backend/spectrum/dguonoff/global/statusCode/CommonCode.java
+++ b/backend/dguonoff/src/main/java/backend/spectrum/dguonoff/global/statusCode/CommonCode.java
@@ -23,6 +23,7 @@ public enum CommonCode {
     //Facility
     SUCCESS_FACILITY_LOOKUP(HttpStatus.OK, "시설 조회가 완료되었습니다."),
     SUCCESS_FACILITY_FINISH(HttpStatus.OK, "성공적으로 시설물 이용이 종료되었습니다."),
+    SUCCESS_FACILITY_NEXT_RESERVATION_LOOKUP(HttpStatus.OK, "시설물의 다음 예약 조회가 완료되었습니다."),
 
 
 

--- a/backend/dguonoff/src/main/java/backend/spectrum/dguonoff/global/statusCode/ErrorCode.java
+++ b/backend/dguonoff/src/main/java/backend/spectrum/dguonoff/global/statusCode/ErrorCode.java
@@ -28,6 +28,7 @@ public enum ErrorCode {
     // Facility
     NOT_EXIST_FACILITY(HttpStatus.NOT_FOUND, "해당 시설물을 찾을 수 없습니다."),
     NOT_DEFINED_RESERVATION_PERIOD(HttpStatus.NOT_FOUND, "정의되지 않은 기준 예약 기간입니다."),
+    NEXT_RESERVATION_NOT_EXIST_FACILITY(HttpStatus.NOT_FOUND, "해당 시설물에 다음 예약이 존재하지 않습니다."),
 
     // Reservation
     NOT_EXIST_RESERVATION(HttpStatus.NOT_FOUND, "존재하지 않는 예약입니다."),


### PR DESCRIPTION
## 관련 이슈 및 링크
- #48 

## 구현 및 변경 사항
- 조회 시점 기준, 시설물의 다음 예약 조회 기능 구현
- 우선적으로 실행중인 예약 조회
- 실행중인 예약이 없으면 다음 예약을 조회
- 다음 일정이 없으면 예외 반환